### PR TITLE
more h5m fixes

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://github.com/fusion-energy/vertices_to_h5m
 license = MIT
-license_file = LICENSE.txt
+license_files = LICENSE.txt
 classifiers =
     Natural Language :: English
     Topic :: Scientific/Engineering


### PR DESCRIPTION
A basic file now looks like

```
HDF5 "some_triangles_h5py.h5m" {
GROUP "/" {
   GROUP "tstt" {
      ATTRIBUTE "max_id" {
         DATATYPE  H5T_STD_U64LE
         DATASPACE  SCALAR
         DATA {
         (0): 10
         }
      }
      GROUP "elements" {
         GROUP "Tri3" {
            ATTRIBUTE "element_type" {
               DATATYPE  "/tstt/elemtypes"
               DATASPACE  SCALAR
               DATA {
               (0): Tri
               }
            }
            DATASET "connectivity" {
               DATATYPE  H5T_STD_U64LE
               DATASPACE  SIMPLE { ( 2, 3 ) / ( 2, 3 ) }
               DATA {
               (0,0): 1, 2, 3,
               (1,0): 1, 3, 4
               }
               ATTRIBUTE "start_id" {
                  DATATYPE  H5T_STD_I64LE
                  DATASPACE  SCALAR
                  DATA {
                  (0): 5
                  }
               }
            }
            GROUP "tags" {
               DATASET "GLOBAL_ID" {
                  DATATYPE  H5T_STD_I64LE
                  DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
                  DATA {
                  (0): 0, 0
                  }
               }
            }
         }
      }
      DATATYPE "elemtypes" H5T_ENUM {
         H5T_STD_U8LE;
         "Edge"             1;
         "Hex"              9;
         "Knife"            8;
         "Polygon"          4;
         "Polyhedron"       10;
         "Prism"            7;
         "Pyramid"          6;
         "Quad"             3;
         "Tet"              5;
         "Tri"              2;
      };
      DATASET "history" {
         DATATYPE  H5T_STRING {
            STRSIZE H5T_VARIABLE;
            STRPAD H5T_STR_NULLTERM;
            CSET H5T_CSET_UTF8;
            CTYPE H5T_C_S1;
         }
         DATASPACE  SIMPLE { ( 4 ) / ( 4 ) }
         DATA {
         (0): "vertices_to_h5m", "0.1.8.dev35+g16ee1cc.d20221128",
         (2): "11/28/22", "18:42:59"
         }
      }
      GROUP "nodes" {
         DATASET "coordinates" {
            DATATYPE  H5T_IEEE_F64LE
            DATASPACE  SIMPLE { ( 4, 3 ) / ( 4, 3 ) }
            DATA {
            (0,0): 0, 0, 0,
            (1,0): 1, 0, 0,
            (2,0): 1, 1, 0,
            (3,0): 0, 1, 0
            }
            ATTRIBUTE "start_id" {
               DATATYPE  H5T_STD_I64LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
         }
         GROUP "tags" {
            DATASET "GLOBAL_ID" {
               DATATYPE  H5T_STD_I64LE
               DATASPACE  SIMPLE { ( 4 ) / ( 4 ) }
               DATA {
               (0): -1, -1, -1, -1
               }
            }
         }
      }
      GROUP "sets" {
         DATASET "children" {
            DATATYPE  H5T_STD_U64LE
            DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
            DATA {
            (0): 7
            }
         }
         DATASET "contents" {
            DATATYPE  H5T_STD_U64LE
            DATASPACE  SIMPLE { ( 5 ) / ( 5 ) }
            DATA {
            (0): 1, 6, 8, 1, 9
            }
         }
         DATASET "list" {
            DATATYPE  H5T_STD_I64LE
            DATASPACE  SIMPLE { ( 4, 4 ) / ( 4, 4 ) }
            DATA {
            (0,0): 1, -1, 0, 10,
            (1,0): 1, 0, 0, 2,
            (2,0): 2, 0, 0, 2,
            (3,0): 4, 0, 0, 10
            }
            ATTRIBUTE "start_id" {
               DATATYPE  H5T_STD_I64LE
               DATASPACE  SCALAR
               DATA {
               (0): 7
               }
            }
         }
         DATASET "parents" {
            DATATYPE  H5T_STD_U64LE
            DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
            DATA {
            (0): 8
            }
         }
         DATASET "tags" {
            DATATYPE  "/tstt/tags/GLOBAL_ID/type"
            DATASPACE  SIMPLE { ( 4 ) / ( 4 ) }
            DATA {
            (0): 1, 1, -1, -1
            }
         }
      }
      GROUP "tags" {
         GROUP "CATEGORY" {
            ATTRIBUTE "class" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
            DATASET "id_list" {
               DATATYPE  H5T_STD_U64LE
               DATASPACE  SIMPLE { ( 3 ) / ( 3 ) }
               DATA {
               (0): 7, 8, 9
               }
            }
            DATATYPE "type" H5T_OPAQUE {
               OPAQUE_TAG "NUMPY:|S32";
            };
            DATASET "values" {
               DATATYPE  "/tstt/tags/CATEGORY/type"
               DATASPACE  SIMPLE { ( 3 ) / ( 3 ) }
               DATA {
               (0): 53:75:72:66:61:63:65:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00,
               (1): 56:6f:6c:75:6d:65:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00,
               (2): 47:72:6f:75:70:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
               }
            }
         }
         GROUP "DIRICHLET_SET" {
            ATTRIBUTE "class" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
            ATTRIBUTE "default" {
               DATATYPE  "/tstt/tags/DIRICHLET_SET/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            ATTRIBUTE "global" {
               DATATYPE  "/tstt/tags/DIRICHLET_SET/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            DATATYPE "type" H5T_STD_I32LE;
         }
         GROUP "GEOM_DIMENSION" {
            ATTRIBUTE "class" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
            ATTRIBUTE "default" {
               DATATYPE  "/tstt/tags/GEOM_DIMENSION/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            ATTRIBUTE "global" {
               DATATYPE  "/tstt/tags/GEOM_DIMENSION/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            DATASET "id_list" {
               DATATYPE  H5T_STD_U64LE
               DATASPACE  SIMPLE { ( 3 ) / ( 3 ) }
               DATA {
               (0): 7, 8, 9
               }
            }
            DATATYPE "type" H5T_STD_I32LE;
            DATASET "values" {
               DATATYPE  "/tstt/tags/GEOM_DIMENSION/type"
               DATASPACE  SIMPLE { ( 3 ) / ( 3 ) }
               DATA {
               (0): 2, 3, 4
               }
            }
         }
         GROUP "GEOM_SENSE_2" {
            ATTRIBUTE "class" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
            ATTRIBUTE "is_handle" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
            DATASET "id_list" {
               DATATYPE  H5T_STD_U64LE
               DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
               DATA {
               (0): 7
               }
            }
            DATATYPE "type" H5T_STD_U32LE;
            DATASET "values" {
               DATATYPE  "/tstt/tags/GEOM_SENSE_2/type"
               DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
               DATA {
               (0): 8, 0
               }
            }
         }
         GROUP "GLOBAL_ID" {
            ATTRIBUTE "class" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 2
               }
            }
            ATTRIBUTE "default" {
               DATATYPE  "/tstt/tags/GLOBAL_ID/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            ATTRIBUTE "global" {
               DATATYPE  "/tstt/tags/GLOBAL_ID/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            DATATYPE "type" H5T_STD_I32LE;
         }
         GROUP "MATERIAL_SET" {
            ATTRIBUTE "class" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
            ATTRIBUTE "default" {
               DATATYPE  "/tstt/tags/MATERIAL_SET/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            ATTRIBUTE "global" {
               DATATYPE  "/tstt/tags/MATERIAL_SET/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            DATATYPE "type" H5T_STD_I32LE;
         }
         GROUP "NAME" {
            ATTRIBUTE "class" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
            DATASET "id_list" {
               DATATYPE  H5T_STD_U64LE
               DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
               DATA {
               (0): 9
               }
            }
            DATATYPE "type" H5T_OPAQUE {
               OPAQUE_TAG "NUMPY:|S32";
            };
            DATASET "values" {
               DATATYPE  "/tstt/tags/NAME/type"
               DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
               DATA {
               (0): 6d:61:74:3a:6d:61:74:31:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
               }
            }
         }
         GROUP "NEUMANN_SET" {
            ATTRIBUTE "class" {
               DATATYPE  H5T_STD_I32LE
               DATASPACE  SCALAR
               DATA {
               (0): 1
               }
            }
            ATTRIBUTE "default" {
               DATATYPE  "/tstt/tags/NEUMANN_SET/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            ATTRIBUTE "global" {
               DATATYPE  "/tstt/tags/NEUMANN_SET/type"
               DATASPACE  SCALAR
               DATA {
               (0): -1
               }
            }
            DATATYPE "type" H5T_STD_I32LE;
         }
      }
   }
}
}
```

All parts are there, just a few things are still hardcoded. Tests may already pass.